### PR TITLE
Fix syntax error in bash

### DIFF
--- a/enhancd.sh
+++ b/enhancd.sh
@@ -566,7 +566,7 @@ cd::interface()
 cd::cd()
 {
     # Add $PWD to the enhancd log
-    cd::add()
+    cd::add
 
     # t is an argument of the list for cd::interface
     local t


### PR DESCRIPTION
```
$ $SHELL --version
GNU bash, version 4.1.2(1)-release (x86_64-redhat-linux-gnu)
Copyright (C) 2009 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

$ source enhancd.sh
bash: enhancd.sh: line 572: syntax error near unexpected token `local'
bash: enhancd.sh: line 572: `    local t'
```

