### PR TITLE
Fixed a bug when splitting string on zsh

### DIFF
--- a/enhancd.sh
+++ b/enhancd.sh
@@ -569,6 +569,10 @@ cd::interface()
 #
 cd::cd()
 {
+    if has "setopt"; then
+        setopt localoptions SH_WORD_SPLIT
+    fi
+
     # t is an argument of the list for cd::interface
     local t
 


### PR DESCRIPTION
I used your awesome library on bash.
This works great!

However, when I used your awesome library on zsh, features which relate with an interactive grep did not work fine.

Zsh does not split a given statement into words by delimiters (e.g. half-width whitespace) if no options. [1]
So Zsh treats `$ENHANCD_FILTER` as one statement if it's replaced each semicolons with a half-width space.
This causes unexpected errors.

`SH_WORD_SPLIT` option can solve this bug.
This patch makes this option enable in only local function scope.

\[1] [http://zsh.sourceforge.net/FAQ/zshfaq03.html](http://zsh.sourceforge.net/FAQ/zshfaq03.html)