### PR TITLE
Fixed jumping to conclusions when 'cd ..'

### DIFF
--- a/enhancd.sh
+++ b/enhancd.sh
@@ -241,7 +241,11 @@ cd::get_abspath()
             nf = length(find)
             for (k = ns+1-nf; k >= 1; k--) {
                 if (substr(string, k, nf) == find) {
-                    return k
+                    if (k > 1 && substr(string, k-1, 1) == "/") {
+                        return k
+                    } else if (k == 1) {
+                        return k
+                    }
                 }
             }
             return 0

--- a/test/enhancd_test.sh
+++ b/test/enhancd_test.sh
@@ -196,5 +196,28 @@ EOF
       rm -r ~/enhancd_test
     end
 
+
+    it "cd::interface .. w/ dup"
+      # before
+      list="$(cat <<EOF
+a
+b
+c
+EOF
+)"
+      mkdir -p ~/enhancd_test/a/b/c/d.c/e/f
+      builtin cd ~/enhancd_test/a/b/c/d.c/e/f
+      fzf() { tail -n 1; }
+      export ENHANCD_FILTER=fzf
+
+      # test
+      expect="$HOME/enhancd_test/a/b/c"
+      actual="$(cd::interface ".." "$list" && pwd)"
+      assert equal "$expect" "$actual"
+
+      # after
+      rm -r ~/enhancd_test
+    end
+
   end
 end


### PR DESCRIPTION
Show #18 .

Fixed following case,

```sh
mkdir -p /foo/com.foo/baz
cd /foo/com.foo/baz
cd .. # then, select 'foo'
# expect $(pwd) == "/foo"
# actual $(pwd) == "/foo/com.foo" #=> actual $(pwd) == "/foo"
```


