### PR TITLE
Use absolute path to avoid user alias

### DIFF
--- a/enhancd.sh
+++ b/enhancd.sh
@@ -416,17 +416,17 @@ cd::makelog()
     fi
 
     # Create a backup in preparation for the failure of the overwriting
-    cp -f "$ENHANCD_DIR"/enhancd.log "$ENHANCD_DIR"/enhancd.backup
-    rm -f "$ENHANCD_DIR"/enhancd.log
+    /bin/cp -f "$ENHANCD_DIR"/enhancd.log "$ENHANCD_DIR"/enhancd.backup
+    /bin/rm -f "$ENHANCD_DIR"/enhancd.log
 
     # Run the overwrite process
-    mv "$esc" "$ENHANCD_DIR"/enhancd.log 2>/dev/null
+    /bin/mv "$esc" "$ENHANCD_DIR"/enhancd.log 2>/dev/null
 
     # Restore from the backup if overwriting fails
     if [ $? -eq 0 ]; then
-        rm -f "$ENHANCD_DIR"/enhancd.backup
+        /bin/rm -f "$ENHANCD_DIR"/enhancd.backup
     else
-        cp -f "$ENHANCD_DIR"/enhancd.backup "$ENHANCD_DIR"/enhancd.log
+        /bin/cp -f "$ENHANCD_DIR"/enhancd.backup "$ENHANCD_DIR"/enhancd.log
     fi
 }
 

--- a/enhancd.sh
+++ b/enhancd.sh
@@ -416,17 +416,17 @@ cd::makelog()
     fi
 
     # Create a backup in preparation for the failure of the overwriting
-    /bin/cp -f "$ENHANCD_DIR"/enhancd.log "$ENHANCD_DIR"/enhancd.backup
-    /bin/rm -f "$ENHANCD_DIR"/enhancd.log
+    command cp -f "$ENHANCD_DIR"/enhancd.log "$ENHANCD_DIR"/enhancd.backup
+    command rm -f "$ENHANCD_DIR"/enhancd.log
 
     # Run the overwrite process
-    /bin/mv "$esc" "$ENHANCD_DIR"/enhancd.log 2>/dev/null
+    command mv "$esc" "$ENHANCD_DIR"/enhancd.log 2>/dev/null
 
     # Restore from the backup if overwriting fails
     if [ $? -eq 0 ]; then
-        /bin/rm -f "$ENHANCD_DIR"/enhancd.backup
+        command rm -f "$ENHANCD_DIR"/enhancd.backup
     else
-        /bin/cp -f "$ENHANCD_DIR"/enhancd.backup "$ENHANCD_DIR"/enhancd.log
+        command cp -f "$ENHANCD_DIR"/enhancd.backup "$ENHANCD_DIR"/enhancd.log
     fi
 }
 


### PR DESCRIPTION
I have this alias in my config
`cp='cp -iv'`
and every time I cd to a directory I receive a message like this
```
‘/home/k1/.enhancd/enhancd.log’ -> ‘/home/k1/.enhancd/enhancd.backup’
‘/home/k1/.enhancd/enhancd.04041608405063961462’ -> ‘/home/k1/.enhancd/enhancd.log’
‘/home/k1/.enhancd/enhancd.log’ -> ‘/home/k1/.enhancd/enhancd.backup’
‘/home/k1/.enhancd/enhancd.040416084050639617392’ -> ‘/home/k1/.enhancd/enhancd.log’
‘/home/k1/.enhancd/enhancd.log’ -> ‘/home/k1/.enhancd/enhancd.backup’
‘/home/k1/.enhancd/enhancd.040416084051639630319’ -> ‘/home/k1/.enhancd/enhancd.log
```  
this commit solves the issue by using absolute path and avoiding any alias may have been defined by user