### PR TITLE
Add escape in gsub

### DIFF
--- a/src/share/get_dirstep.awk
+++ b/src/share/get_dirstep.awk
@@ -1,7 +1,7 @@
 BEGIN {
     count = gsub(/\//, "/", dir);
     for (i = 0; i < count; i++) {
-        gsub(/\/[^/]*$/, "", dir);
+        gsub(/\/[^\/]*$/, "", dir);
         if (dir == "")
             print "/";
         else


### PR DESCRIPTION
Fix the following error:

```
awk: extra ] at source line 4 source file ~/.zplug/repos/b4b4r07/enhancd/src/share/get_dirstep.awk
 context is
	        >>>  gsub(/\/[^/] <<< 
awk: nonterminated character class \/[^
 source line number 4 source file ~/.zplug/repos/b4b4r07/enhancd/src/share/get_dirstep.awk
```

My enviroment is OS X 10.11, and awk version 20070501.
