### PR TITLE
Fix wrong directory name when ENHANCD_DOT_SHOW_FULLPATH=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ ENHANCD_COMMAND=ecd; export ENHANCD_COMMAND
 
 ### `ENHANCD_DOT_SHOW_FULLPATH`
 
-The ENHANCD_DOT_SHOW_FULLPATH environment variable is to set whether to show full path or not when executing Double-dot. It defaults to `0`.
+The ENHANCD_DOT_SHOW_FULLPATH environment variable is to set whether to show the full path or not when executing Double-dot. It defaults to `0`.
 
 ```console
 $ export ENHANCD_DOT_SHOW_FULLPATH=1

--- a/src/share/split_path.awk
+++ b/src/share/split_path.awk
@@ -42,4 +42,3 @@ function has_prefix(s, pre,        pre_len, s_len) {
 function isabs(pathname) {
     return length(pathname) > 0 && has_prefix(pathname, "/")
 }
-

--- a/src/share/split_path.awk
+++ b/src/share/split_path.awk
@@ -12,12 +12,19 @@ BEGIN {
     # display the beginning of the path
     print substr(arg, 1, 1)
 
-    # decompose the path by a slash
-    for (i = 1; i < num; i++) {
-        if (show_fullpath == 1) {
-            split(s, dirname, arr[i])
-            print "/" dirname[1] arr[i]
-        } else {
+    if (show_fullpath == 1) {
+        # get dirname from /
+        num = split(s, dirname, "/")
+        for (i = 1; i < num; i++) {
+            pre_dir = ""
+            for (ii = 1; ii <= i; ii++) {
+                pre_dir = pre_dir "/" dirname[ii]
+            }
+            print pre_dir
+        }
+    } else {
+        # decompose the path by a slash
+        for (i = 1; i < num; i++) {
             print arr[i]
         }
     }
@@ -35,3 +42,4 @@ function has_prefix(s, pre,        pre_len, s_len) {
 function isabs(pathname) {
     return length(pathname) > 0 && has_prefix(pathname, "/")
 }
+

--- a/test/enhancd-enhancd_test.sh
+++ b/test/enhancd-enhancd_test.sh
@@ -71,8 +71,17 @@ T_SUB "__enhancd::split_path()" ((
 
   T_SUB "With \$ENHANCD_DOT_SHOW_FULLPATH when the same directory name set" ((
     ENHANCD_DOT_SHOW_FULLPATH=1
-    expect="/${LF}/home${LF}/home/lisa${LF}/home/lisa"
-    actual="$(__enhancd::split_path /home/lisa/work/home)"
+
+    expect="/${LF}/home${LF}/home/lisa${LF}/home/lisa/home"
+    actual="$(__enhancd::split_path /home/lisa/home/work)"
+    t_is "$expect" "$actual"
+
+    expect="/${LF}/home${LF}/home/lisa${LF}/home/lisa/home${LF}/home/lisa/home/work"
+    actual="$(__enhancd::split_path /home/lisa/home/work/home)"
+    t_is "$expect" "$actual"
+
+    expect="/${LF}/home${LF}/home/lisa${LF}/home/lisa/home-foo"
+    actual="$(__enhancd::split_path /home/lisa/home-foo/work)"
     t_is "$expect" "$actual"
   ))
 ))

--- a/test/enhancd-enhancd_test.sh
+++ b/test/enhancd-enhancd_test.sh
@@ -57,6 +57,7 @@ T_SUB "__enhancd::get_abspath()" ((
 ))
 
 T_SUB "__enhancd::split_path()" ((
+  ENHANCD_DOT_SHOW_FULLPATH=0
   expect="/${LF}home${LF}lisa"
   actual="$(__enhancd::split_path /home/lisa/work)"
   t_is "$expect" "$actual"
@@ -65,6 +66,13 @@ T_SUB "__enhancd::split_path()" ((
     ENHANCD_DOT_SHOW_FULLPATH=1
     expect="/${LF}/home${LF}/home/lisa"
     actual="$(__enhancd::split_path /home/lisa/work)"
+    t_is "$expect" "$actual"
+  ))
+
+  T_SUB "With \$ENHANCD_DOT_SHOW_FULLPATH when the same directory name set" ((
+    ENHANCD_DOT_SHOW_FULLPATH=1
+    expect="/${LF}/home${LF}/home/lisa${LF}/home/lisa"
+    actual="$(__enhancd::split_path /home/lisa/work/home)"
     t_is "$expect" "$actual"
   ))
 ))
@@ -77,6 +85,8 @@ T_SUB "__enhancd::get_dirstep()" ((
 
 T_SUB "__enhancd::get_dirname()" ((
   # Basically, the same as __enhancd::split_path
+  ENHANCD_DOT_SHOW_FULLPATH=0
+
   expect="/${LF}home${LF}lisa"
   actual="$(__enhancd::get_dirname /home/lisa/work)"
   t_is "$expect" "$actual"


### PR DESCRIPTION
I added the ENHANCD_DOT_SHOW_FULLPATH environment variable at #42 .
But there is a bug when the current directory includes the same directory name set:

```console
% pwd
/home/lisa/home/work
% cd ..
1: /
2: /home
3: /home/lisa
4: /home
```

I fixed this bug by changing the logic of `src/share/split_path.awk`.

My environment:
mawk 1.3.3 Nov 1996, Ubuntu 16.04