### PR TITLE
Fix issue that init routine runs in global scope

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -26,6 +26,7 @@ else
     return 1
 fi
 
+__enhancd::init::init()
 {
     # core files
     for src in "$ENHANCD_ROOT/src"/*.sh
@@ -67,3 +68,5 @@ fi
         setopt localoptions SH_WORD_SPLIT
     fi
 } &>/dev/null
+
+__enhancd::init::init

--- a/init.sh
+++ b/init.sh
@@ -26,7 +26,7 @@ else
     return 1
 fi
 
-() {
+{
     # core files
     for src in "$ENHANCD_ROOT/src"/*.sh
     do

--- a/init.sh
+++ b/init.sh
@@ -67,6 +67,6 @@ __enhancd::init::init()
         # (Zsh Manual 14.3 Parameter Expansion)
         setopt localoptions SH_WORD_SPLIT
     fi
-} &>/dev/null
+}
 
 __enhancd::init::init

--- a/init.sh
+++ b/init.sh
@@ -26,7 +26,7 @@ else
     return 1
 fi
 
-{
+() {
     # core files
     for src in "$ENHANCD_ROOT/src"/*.sh
     do


### PR DESCRIPTION
Fix issue that init routine runs in global scope. (Especially, setopt influences global environment.)
