### PR TITLE
Unalias error

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -48,9 +48,6 @@ __enhancd::init::init()
 
     # alias to cd
     eval "alias ${ENHANCD_COMMAND:=cd}=__enhancd::cd"
-    if [[ $ENHANCD_COMMAND != cd ]]; then
-        unalias cd
-    fi
 
     # Set the filter if empty
     if [[ -z $ENHANCD_FILTER ]]; then


### PR DESCRIPTION
Should fix this error: __enhancd::init::init:unalias:23: no such hash table element: cd

If ENHANCD_COMMAND is not set, or is not set to cd