### PR TITLE
add: skip mkdir and touch if exist

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -43,8 +43,12 @@ __enhancd::init::init()
     unset src
 
     # make a log file and a root directory
-    mkdir -p "$ENHANCD_DIR"
-    touch "$ENHANCD_DIR/enhancd.log"
+    if [ ! -d "$ENHANCD_DIR" ]; then
+      mkdir -p "$ENHANCD_DIR"
+    fi
+    if [ ! -f "$ENHANCD_DIR/enhancd.log" ]; then
+      touch "$ENHANCD_DIR/enhancd.log"
+    fi
 
     # alias to cd
     eval "alias ${ENHANCD_COMMAND:=cd}=__enhancd::cd"


### PR DESCRIPTION
for satrt up speed issue

In my environment, original enhancd takes 22ms to load.

```
num  calls                time                       self            name
-----------------------------------------------------------------------------------
num  calls                time                       self            name
-----------------------------------------------------------------------------------
 1)    9         165.33    18.37   99.91%     45.99     5.11   27.79%  loadlib
 2)    1          27.30    27.30   16.50%     26.93    26.93   16.27%  _zsh_highlight_load_highlighters
 3)    1          26.18    26.18   15.82%     26.18    26.18   15.82%  _zsh_highlight_bind_widgets
 4)    1          22.43    22.43   13.56%     22.33    22.33   13.49%  __enhancd::init::init
 5)    2          15.41     7.71    9.31%     15.41     7.71    9.31%  promptinit
 6)    1           8.49     8.49    5.13%      8.49     8.49    5.13%  compinit
```

After a little profile, I found out that `mkdir` and `touch` in init.sh taking half of loading time.

So I modified to skip it if those exist. It becomes 2 times faster.

```
num  calls                time                       self            name
-----------------------------------------------------------------------------------
num  calls                time                       self            name
-----------------------------------------------------------------------------------
 1)    9         147.67    16.41   99.87%     56.13     6.24   37.96%  loadlib
 2)    1          27.18    27.18   18.38%     26.83    26.83   18.14%  _zsh_highlight_load_highlighters
 3)    1          24.25    24.25   16.40%     24.25    24.25   16.40%  _zsh_highlight_bind_widgets
 4)    1          10.77    10.77    7.29%     10.68    10.68    7.22%  __enhancd::init::init
 5)    1           8.61     8.61    5.82%      8.61     8.61    5.82%  compinit
```
