### PR TITLE
Fix that shwordsplit doesn't work properly.

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -57,17 +57,6 @@ __enhancd::init::init()
     if [[ -z $ENHANCD_FILTER ]]; then
         ENHANCD_FILTER="fzy:fzf-tmux:fzf:peco:percol:gof:pick:icepick:sentaku:selecta"
     fi
-
-    # In zsh it will cause field splitting to be performed
-    # on unquoted parameter expansions.
-    if __enhancd::utils::has "setopt" && [[ -n $ZSH_VERSION ]]; then
-        # Note in particular the fact that words of unquoted parameters are not
-        # automatically split on whitespace unless the option SH_WORD_SPLIT is set;
-        # see references to this option below for more details.
-        # This is an important difference from other shells.
-        # (Zsh Manual 14.3 Parameter Expansion)
-        setopt localoptions SH_WORD_SPLIT
-    fi
 }
 
 __enhancd::init::init

--- a/src/filter.sh
+++ b/src/filter.sh
@@ -85,7 +85,7 @@ __enhancd::filter::interactive()
             ;;
         * )
             local t
-            t="$(echo "$list" | $filter)"
+            t="$(echo "$list" | eval $filter)"
             if [[ -z $t ]]; then
                 # No selection
                 return 0


### PR DESCRIPTION
## Summary
`setopt localoptions SH_WORD_SPLIG` is unneeded, because shwordsplit isn't enabled in global environment.

Instead `eval` command use to execute the `$filter` command.

### What's the problem

In fact, this script below didn't work I expected.
```zsh
export ENHANCD_FILTER="fzf-tmux -u 10%:peco:fzf"
zplug "b4b4r07/enhancd", use:init.sh
```

```zsh
❯ cd
__enhancd::filter::interactive:28: command not found: fzf-tmux -d 10%
```

Because the line (`setopt localoptions SH_WORD_SPLIT`) means `shwordsplit` only enable in local: `__enhancd::init::init()`. But `$filter` command is executed at `__enhancd::filter::interactive()` function. So `shwordsplit` is disabled at that time.

### Solutions
`shwordsplit` enabled in global, for example execute `setopt SH_WORD_SPLIT`. But if `shwordsplit` is set in global, whole shell environment may be affected, so the idea is bad.

Instead let's use `eval` command or something similar.

Thanks.