### PR TITLE
FreeBSD awk throws errors if the fifos are closed too early

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -11,6 +11,7 @@ export ENHANCD_DOT_ARG="${ENHANCD_DOT_ARG:-..}"
 export ENHANCD_HYPHEN_ARG="${ENHANCD_HYPHEN_ARG:--}"
 export ENHANCD_DOT_SHOW_FULLPATH="${ENHANCD_DOT_SHOW_FULLPATH:-0}"
 export ENHANCD_USE_FUZZY_MATCH="${ENHANCD_USE_FUZZY_MATCH:-1}"
+export ENHANCD_AWK
 
 _ENHANCD_VERSION="2.2.2"
 _ENHANCD_SUCCESS=0
@@ -57,6 +58,20 @@ __enhancd::init::init()
     if [[ -z $ENHANCD_FILTER ]]; then
         ENHANCD_FILTER="fzy:fzf-tmux:fzf:peco:percol:gof:pick:icepick:sentaku:selecta"
     fi
+
+    # In zsh it will cause field splitting to be performed
+    # on unquoted parameter expansions.
+    if __enhancd::utils::has "setopt" && [[ -n $ZSH_VERSION ]]; then
+        # Note in particular the fact that words of unquoted parameters are not
+        # automatically split on whitespace unless the option SH_WORD_SPLIT is set;
+        # see references to this option below for more details.
+        # This is an important difference from other shells.
+        # (Zsh Manual 14.3 Parameter Expansion)
+        setopt localoptions SH_WORD_SPLIT
+    fi
+
+    ENHANCD_AWK="$(__enhancd::utils::awk)"
+
 }
 
 __enhancd::init::init

--- a/src/arguments.sh
+++ b/src/arguments.sh
@@ -4,7 +4,7 @@ __enhancd::arguments::option()
 
     cat "$ENHANCD_ROOT/src/custom/config.ltsv" \
         | __enhancd::utils::grep -v '^(//|#)' \
-        | awk -F$'\t' '/:'"$opt"'\t/{print $4}' \
+        | $ENHANCD_AWK -F$'\t' '/:'"$opt"'\t/{print $4}' \
         | cut -d: -f2 \
         | read action
 

--- a/src/filter.sh
+++ b/src/filter.sh
@@ -16,7 +16,7 @@ __enhancd::filter::join()
         cat "$1"
     else
         cat <&0
-    fi | awk 'a[$0]++' 2>/dev/null
+    fi | $ENHANCD_AWK 'a[$0]++' 2>/dev/null
 }
 
 # __enhancd::filter::unique uniques a stdin contents
@@ -26,7 +26,7 @@ __enhancd::filter::unique()
         cat "$1"
     else
         cat <&0
-    fi | awk '!a[$0]++' 2>/dev/null
+    fi | $ENHANCD_AWK '!a[$0]++' 2>/dev/null
 }
 
 # __enhancd::filter::reverse reverses a stdin contents
@@ -37,7 +37,7 @@ __enhancd::filter::reverse()
     else
         cat <&0
     fi \
-        | awk -f "$ENHANCD_ROOT/src/share/reverse.awk" \
+        | $ENHANCD_AWK -f "$ENHANCD_ROOT/src/share/reverse.awk" \
         2>/dev/null
 }
 
@@ -47,12 +47,12 @@ __enhancd::filter::fuzzy()
         cat <&0
     else
         if [[ $ENHANCD_USE_FUZZY_MATCH == 1 ]]; then
-            awk \
+            $ENHANCD_AWK \
                 -f "$ENHANCD_ROOT/src/share/fuzzy.awk" \
                 -v search_string="$1"
         else
             # Case-insensitive (don't use fuzzy searhing)
-            awk '$0 ~ /\/.?'"$1"'[^\/]*$/{print $0}' 2>/dev/null
+            $ENHANCD_AWK '$0 ~ /\/.?'"$1"'[^\/]*$/{print $0}' 2>/dev/null
         fi
     fi
 }
@@ -85,7 +85,7 @@ __enhancd::filter::interactive()
             ;;
         * )
             local t
-            t="$(echo "$list" | eval $filter)"
+            t="$(echo "$list" | $filter)"
             if [[ -z $t ]]; then
                 # No selection
                 return 0

--- a/src/path.sh
+++ b/src/path.sh
@@ -27,7 +27,7 @@ __enhancd::path::to_abspath()
         fi
     else
         # If there are no duplicate directory name
-        awk \
+        $ENHANCD_AWK \
             -f "$ENHANCD_ROOT/src/share/to_abspath.awk" \
             -v cwd="$cwd" \
             -v dir="$dir"
@@ -37,7 +37,7 @@ __enhancd::path::to_abspath()
 # __enhancd::path::split decomposes the path with a slash as a delimiter
 __enhancd::path::split()
 {
-    awk \
+    $ENHANCD_AWK \
         -f "$ENHANCD_ROOT/src/share/split.awk" \
         -v arg="${1:-$PWD}" #-v show_fullpath="$ENHANCD_DOT_SHOW_FULLPATH"
 }
@@ -45,7 +45,7 @@ __enhancd::path::split()
 # __enhancd::path::step_by_step returns a list of stepwise path
 __enhancd::path::step_by_step()
 {
-    awk \
+    $ENHANCD_AWK \
         -f "$ENHANCD_ROOT/src/share/step_by_step.awk" \
         -v dir="${1:-$PWD}"
 }
@@ -65,9 +65,9 @@ __enhancd::path::go_upstairs()
 
     # uniq is the variable that checks whether there is
     # the duplicate directory in the PWD environment variable
-    if __enhancd::path::split "$dir" | awk -f "$ENHANCD_ROOT/src/share/has_dup_lines.awk"; then
+    if __enhancd::path::split "$dir" | $ENHANCD_AWK -f "$ENHANCD_ROOT/src/share/has_dup_lines.awk"; then
         __enhancd::path::split "$dir" \
-            | awk '{ printf("%d: %s\n", NR, $0); }'
+            | $ENHANCD_AWK '{ printf("%d: %s\n", NR, $0); }'
     else
         __enhancd::path::split "$dir"
     fi

--- a/src/utils.sh
+++ b/src/utils.sh
@@ -102,7 +102,7 @@ __enhancd::utils::has()
 __enhancd::utils::nl()
 {
     # d in awk's argument is a delimiter
-    awk -v d="${1:-": "}" '
+    $ENHANCD_AWK -v d="${1:-": "}" '
     BEGIN {
         i = 1
     }
@@ -110,4 +110,14 @@ __enhancd::utils::nl()
         print i d $0
         i++
     }' 2>/dev/null
+}
+
+# __enhancd::utils::awk returns gawk if found, else awk
+__enhancd::utils::awk()
+{
+    if [[ "$(uname -s)" == "FreeBSD" ]]; then
+        [[ $(command -v gawk) ]] && echo "gawk" || echo "awk"
+    else
+        echo "awk"
+    fi
 }


### PR DESCRIPTION
This patch makes the used awk version dynamic. On FreeBSD, if gawk (GNU awk) is found it is used else awk is selected. For other OSes it's always awk.

This removes these errors when used with some other plugins:

awk: i/o error occurred while closing /dev/stdin
 source line number 3