### PR TITLE
Fix that shwordsplit doesn't work properly.

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -61,19 +61,7 @@ __enhancd::init::init()
         ENHANCD_FILTER="fzy:fzf-tmux:fzf:peco:percol:gof:pick:icepick:sentaku:selecta"
     fi
 
-    # In zsh it will cause field splitting to be performed
-    # on unquoted parameter expansions.
-    if __enhancd::utils::has "setopt" && [[ -n $ZSH_VERSION ]]; then
-        # Note in particular the fact that words of unquoted parameters are not
-        # automatically split on whitespace unless the option SH_WORD_SPLIT is set;
-        # see references to this option below for more details.
-        # This is an important difference from other shells.
-        # (Zsh Manual 14.3 Parameter Expansion)
-        setopt localoptions SH_WORD_SPLIT
-    fi
-
     ENHANCD_AWK="$(__enhancd::utils::awk)"
-
 }
 
 __enhancd::init::init

--- a/src/filter.sh
+++ b/src/filter.sh
@@ -85,7 +85,7 @@ __enhancd::filter::interactive()
             ;;
         * )
             local t
-            t="$(echo "$list" | $filter)"
+            t="$(echo "$list" | eval $filter)"
             if [[ -z $t ]]; then
                 # No selection
                 return 0


### PR DESCRIPTION
## WHAT
`setopt localoptions SH_WORD_SPLIG` is unneeded, because shwordsplit
isn't enabled in global environment. Instead `eval` command use to
execute the `$filter` command.

## WHY
The patch was originially introduced by @asakasa in 5e1541ad3a4819978e4572bbe5d6b961a799f4e3
and then reverted in part by @aperum in 1c41d74c52f81db8fd2410cbe897e9a8c0fc7590 for no reason that I can see.
That broke the correct evaliation of the ENHANCD_FILTER, causing `cd ` to fail in current HEAD.

To me, this looks like an unclean merge, hence I am simply re-introducing the original patch.
If anyone mentioned would like to correct my interpretation of events, please feel free to do so.
