### PR TITLE
Fix the check of awk command existence

### DIFF
--- a/src/utils.sh
+++ b/src/utils.sh
@@ -115,9 +115,5 @@ __enhancd::utils::nl()
 # __enhancd::utils::awk returns gawk if found, else awk
 __enhancd::utils::awk()
 {
-    if [[ "$(uname -s)" == "FreeBSD" ]]; then
-        [[ $(command -v gawk) ]] && echo "gawk" || echo "awk"
-    else
-        echo "awk"
-    fi
+    which gawk > /dev/null 2>&1 && echo "gawk" || echo "awk"
 }


### PR DESCRIPTION
## WHAT
Fix the check of awk command existence in `src/utils.sh`

## WHY
The checking of current master does not work in my environment.
https://github.com/b4b4r07/enhancd/blob/b8c1c2e7047903a0f2dc6637c8219d49f3c03fc4/src/utils.sh#L119

```sh
# log
$ [[ $(command -v gawk) ]] && echo "gawk" || echo "awk"
zsh: parse error near `]]'
```

And I think it does not needed to check the `uname`, so I removed an unnecessary part.

## MY ENVIRONMENT
```
$ cat /etc/redhat-release
CentOS Linux release 7.5.1804 (Core)

$ zsh --version
zsh 5.0.2 (x86_64-redhat-linux-gnu)
```