### PR TITLE
Fix builtin cd arguments

### DIFF
--- a/src/cd.sh
+++ b/src/cd.sh
@@ -85,7 +85,7 @@ __enhancd::cd()
 
     case $ret in
         $_ENHANCD_SUCCESS)
-            __enhancd::cd::builtin ${opts[@]} ${args[@]}
+            __enhancd::cd::builtin "${opts[@]}" "${args[@]}"
             ret=$?
             ;;
         $_ENHANCD_FAILURE)


### PR DESCRIPTION
```console
$ mkdir "foo bar baz"
$ cd foo\ bar\ baz
__enhancd::cd::builtin:cd:10: too many arguments
```