### PR TITLE
Fix builtin cd arguments

### DIFF
--- a/src/cd.sh
+++ b/src/cd.sh
@@ -49,6 +49,12 @@ __enhancd::cd()
                 args+=( "$(__enhancd::sources::default)" )
                 code=$?
                 ;;
+            --)
+                opts+=( "${1}" )
+                shift
+                args+=( "$(__enhancd::sources::argument "$1")" )
+                code=$?
+                ;;
             -* | --*)
                 if __enhancd::flag::is_default "${1}"; then
                     opts+=( "${1}" )


### PR DESCRIPTION
```console
$ mkdir -p foo/bar/baz
$ ln -s -- foo/bar/baz -baz
$ cd -P -- -baz
--: no such option
-baz: no such option
```