### PR TITLE
ENHANCD_HOME_ARG not working

### DIFF
--- a/src/cd.sh
+++ b/src/cd.sh
@@ -73,7 +73,7 @@ __enhancd::cd()
 
     case ${#args[@]} in
         0)
-            args+=( "$(__enhancd::sources::default)" )
+            args+=( "$(__enhancd::sources::default 0)" )
             code=$?
             ;;
     esac

--- a/src/sources.sh
+++ b/src/sources.sh
@@ -47,7 +47,7 @@ __enhancd::sources::mru()
 
 __enhancd::sources::default()
 {
-    if [[ $ENHANCD_DISABLE_HOME == 1 ]]; then
+    if [[ $ENHANCD_DISABLE_HOME == 1 && $# == 1 ]]; then
         echo "$HOME"
         return 0
     fi


### PR DESCRIPTION
When both ENHANCD_HOME_ARG and ENHANCD_DISABLE_HOME are set, you should
return $HOME to `cd`, but do Interactive selection to
`cd $ENHANCD_HOME_ARG` as documented.

## WHAT
Passing extra argument to __enhancd::sources::default make it possible to distinguish between calls `cd` and `cd $ENHANCD_HOME_ARG`.

## WHY
See table below, right most case.
I want to use ENHANCD_HOME_ARG and `cd` to get $HOME, but it's not working.
As documented, to achieve this ideal config I changed two files.

|  | | | | |
|:--------------------:|:-----------:|:-----:|:------------:|:-----------:|
| ENHANCD_HOME_ARG     | empty       | empty | Not empty    |   Not empty |
| ENHANCD_DISABLE_HOME | 0           | 1     | 0            | 1           |
| **Ideal** | | | | |
| cd                   | Interactive | $HOME | Interactive  | $HOME       |
| cd $ENHANCD_HOME_ARG |             |       | Interactive  | Interactive |
| **Current** | | | | |
| cd                   | Interactive | $HOME | Interactive  | $HOME       |
| cd $ENHANCD_HOME_ARG |             |       | Interactive  | $HOME       |

Passing 0 like a flag is a bit confusing though.
