### PR TITLE
Fix cd back to ~/ when aborting fuzzy selection with fish shell

### DIFF
--- a/functions/_enhancd_filter_interactive.fish
+++ b/functions/_enhancd_filter_interactive.fish
@@ -24,7 +24,7 @@ function _enhancd_filter_interactive
         case '*'
             set -l selected (echo "$stdin" | eval "$filter")
             if [ -z "$selected" ]
-                return 0
+                echo "$PWD"
             end
             echo "$selected"
     end


### PR DESCRIPTION
## WHAT
If no directory is selected in fuzzy list, `cd` to the current directory

## WHY
When aborting a fuzzy selection on fish (i.e : pressing `esc` key when fuzzy list is opened), nothing is sent as argument to `cd`, so it comes back to `~/`, which is not the excpected behaviour

