### PR TITLE
Use short options with BSD "rm" command

### DIFF
--- a/conf.d/enhancd.fish
+++ b/conf.d/enhancd.fish
@@ -60,5 +60,10 @@ end
 eval "alias $ENHANCD_COMMAND 'enhancd'"
 
 function $name_uninstall --on-event $name_uninstall
-    rm --force --recursive --dir $ENHANCD_DIR
+    switch (command uname)
+        case Darwin \*BSD
+            rm -rf $ENHANCD_DIR
+        case \*
+            rm --force --recursive --dir $ENHANCD_DIR
+    end
 end

--- a/uninstall.fish
+++ b/uninstall.fish
@@ -3,4 +3,9 @@
 # You can use this file to do custom cleanup when the package is uninstalled.
 # You can use the variable $path to access the package path.
 
-rm --force --recursive --dir $ENHANCD_DIR
+switch (command uname)
+    case Darwin \*BSD
+        rm -rf $ENHANCD_DIR
+    case \*
+        rm --force --recursive --dir $ENHANCD_DIR
+end


### PR DESCRIPTION
## WHAT
This patch adds a check during uninstall for systems with BSD `rm`, such as macOS, and calls it with short options.

## WHY
This patch corrects the following error during uninstallation on macOS:
```
rm: illegal option -- -
usage: rm [-f | -i] [-dPRrvW] file ...
       unlink file
```
