### PR TITLE
Remove long options from rm command

### DIFF
--- a/conf.d/enhancd.fish
+++ b/conf.d/enhancd.fish
@@ -60,5 +60,5 @@ end
 eval "alias $ENHANCD_COMMAND 'enhancd'"
 
 function $name_uninstall --on-event $name_uninstall
-    rm --force --recursive --dir $ENHANCD_DIR
+    rm -rf $ENHANCD_DIR
 end

--- a/uninstall.fish
+++ b/uninstall.fish
@@ -3,4 +3,4 @@
 # You can use this file to do custom cleanup when the package is uninstalled.
 # You can use the variable $path to access the package path.
 
-rm --force --recursive --dir $ENHANCD_DIR
+rm -rf $ENHANCD_DIR


### PR DESCRIPTION
## WHAT
Use `rm -rf` instead of `rm --force --recursive --dir`.

## WHY
On macOS, the `rm` command does not support long options `--force`, `--recursive`, `--dir`, etc.

Related: jorgebucaran/fisher#560