### PR TITLE
Prevent sources deletion

### DIFF
--- a/conf.d/enhancd.fish
+++ b/conf.d/enhancd.fish
@@ -47,15 +47,6 @@ if ! [ -f "$ENHANCD_DIR/enhancd.log" ]
     touch "$ENHANCD_DIR/enhancd.log"
 end
 
-# Remove bash/zsh sources
-if [ -d "$ENHANCD_ROOT/src" ]
-    rm -rf "$ENHANCD_ROOT/src"
-end
-
-if [ -f "$ENHANCD_ROOT/init.sh" ]
-    rm -f "$ENHANCD_ROOT/init.sh"
-end
-
 # alias to enhancd
 eval "alias $ENHANCD_COMMAND 'enhancd'"
 

--- a/init.fish
+++ b/init.fish
@@ -44,14 +44,5 @@ if ! [ -f "$ENHANCD_DIR/enhancd.log" ]
     touch "$ENHANCD_DIR/enhancd.log"
 end
 
-# Remove bash/zsh sources
-if [ -d "$ENHANCD_ROOT/src" ]
-    rm -rf "$ENHANCD_ROOT/src"
-end
-
-if [ -f "$ENHANCD_ROOT/init.sh" ]
-    rm -f "$ENHANCD_ROOT/init.sh"
-end
-
 # alias to enhancd
 eval "alias $ENHANCD_COMMAND 'enhancd'"

--- a/init.sh
+++ b/init.sh
@@ -71,23 +71,6 @@ __enhancd::init::init()
     if [[ -z $ENHANCD_FILTER ]]; then
         ENHANCD_FILTER="fzy:fzf-tmux:fzf:peco:percol:gof:pick:icepick:sentaku:selecta"
     fi
-
-    # Remove fish sources
-    if [[ -d "$ENHANCD_ROOT"/functions ]]; then
-        rm -rfd "$ENHANCD_ROOT"/functions
-    fi
-
-    if [[ -d "$ENHANCD_ROOT"/conf.d ]]; then
-        rm -rfd "$ENHANCD_ROOT"/conf.d
-    fi
-
-    if [[ -f "$ENHANCD_ROOT"/init.fish ]]; then
-        rm -f "$ENHANCD_ROOT"/init.fish
-    fi
-
-    if [[ -f "$ENHANCD_ROOT"/uninstall.fish ]]; then
-        rm -f "$ENHANCD_ROOT"/uninstall.fish
-    fi
 }
 
 __enhancd::init::init


### PR DESCRIPTION
## WHAT
Don't delete bash sources when installing with fish (and vice versa) 

## WHY
It's an unexpected behavior, and causes issues when using multiple shell (#123)
