### PR TITLE
Fix fisher uninstall function

### DIFF
--- a/conf.d/enhancd.fish
+++ b/conf.d/enhancd.fish
@@ -60,4 +60,24 @@ eval "alias $ENHANCD_COMMAND 'enhancd'"
 
 function __$name_uninstall --on-event $name_uninstall
     rm --force --recursive --dir $ENHANCD_DIR
+
+    set --erase ENHANCD_FILTER
+    set --erase ENHANCD_COMMAND
+    set --erase ENHANCD_ROOT
+    set --erase ENHANCD_DIR
+    set --erase ENHANCD_DISABLE_DOT
+    set --erase ENHANCD_DISABLE_HYPHEN
+    set --erase ENHANCD_DISABLE_HOME
+    set --erase ENHANCD_DOT_ARG
+    set --erase ENHANCD_HYPHEN_ARG
+    set --erase ENHANCD_HYPHEN_NUM
+    set --erase ENHANCD_HOME_ARG
+    set --erase ENHANCD_USE_FUZZY_MATCH
+    set --erase ENHANCD_COMPLETION_DEFAULT
+    set --erase ENHANCD_COMPLETION_BEHAVIOUR
+    set --erase ENHANCD_COMPLETION_KEYBIND
+    set --erase ENHANCD_FILTER
+    set --erase _ENHANCD_VERSION
+    set --erase _ENHANCD_SUCCESS
+    set --erase _ENHANCD_FAILURE
 end

--- a/conf.d/enhancd.fish
+++ b/conf.d/enhancd.fish
@@ -6,8 +6,7 @@
 # * $dependencies  package dependencies
 
 set -l name (basename (status -f) .fish)
-set -l name_uninstall $name{_uninstall}
-
+set -l name_uninstall {$name}_uninstall
 # set variables
 set -gx ENHANCD_FILTER
 
@@ -59,6 +58,6 @@ end
 # alias to enhancd
 eval "alias $ENHANCD_COMMAND 'enhancd'"
 
-function $name_uninstall --on-event $name_uninstall
+function __$name_uninstall --on-event $name_uninstall
     rm --force --recursive --dir $ENHANCD_DIR
 end


### PR DESCRIPTION
## WHAT
- Fix uninstall function used by fisher
- Unset enhancd variables when uninstalling

## WHY
Function name wasn't properly set, so function wasn't called when removing enhancd with `fisher rm b4b4r07/enhancd`.
There is no need to keep configuration variables after removal, so let's unset them in the uninstall hook.