### PR TITLE
Fix awk scripts paths in fish functions

### DIFF
--- a/conf.d/enhancd.fish
+++ b/conf.d/enhancd.fish
@@ -3,8 +3,6 @@ function __enhancd_install --on-event enhancd_install
     set -Ux ENHANCD_FILTER
     set -Ux ENHANCD_COMMAND "cd"
 
-    set -Ux ENHANCD_ROOT $path
-
     set -Ux ENHANCD_ROOT "$fisher_path/functions/enhancd"
 
     set -Ux ENHANCD_DIR "$HOME/.enhancd"

--- a/functions/_enhancd_filepath_abs.fish
+++ b/functions/_enhancd_filepath_abs.fish
@@ -16,7 +16,7 @@ function _enhancd_filepath_abs
     echo "cwd : -$cwd- -- dir : -$dir-" >$HOME/debug.txt
 
     _enhancd_command_awk \
-        -f "$ENHANCD_ROOT/functions/enhancd/lib/to_abspath.awk" \
+        -f "$ENHANCD_ROOT/lib/to_abspath.awk" \
         -v cwd="$cwd" \
         -v dir="$dir"
 end

--- a/functions/_enhancd_filepath_list_step.fish
+++ b/functions/_enhancd_filepath_list_step.fish
@@ -5,6 +5,6 @@ function _enhancd_filepath_list_step
     end
 
     _enhancd_command_awk \
-        -f "$ENHANCD_ROOT/functions/enhancd/lib/step_by_step.awk" \
+        -f "$ENHANCD_ROOT/lib/step_by_step.awk" \
         -v dir="$argv[1]"
 end

--- a/functions/_enhancd_filepath_split.fish
+++ b/functions/_enhancd_filepath_split.fish
@@ -5,6 +5,6 @@ function _enhancd_filepath_split
     end
 
     _enhancd_command_awk \
-        -f "$ENHANCD_ROOT/functions/enhancd/lib/split.awk" \
+        -f "$ENHANCD_ROOT/lib/split.awk" \
         -v arg=$argv[1]
 end

--- a/functions/_enhancd_filter_fuzzy.fish
+++ b/functions/_enhancd_filter_fuzzy.fish
@@ -4,7 +4,7 @@ function _enhancd_filter_fuzzy
     else
         if test "$ENHANCD_USE_FUZZY_MATCH" = 1
             _enhancd_command_awk \
-                -f "$ENHANCD_ROOT/functions/enhancd/lib/fuzzy.awk" \
+                -f "$ENHANCD_ROOT/lib/fuzzy.awk" \
                 -v search_string="$argv[1]"
         else
             # Case-insensitive (don't use fuzzy searhing)

--- a/functions/_enhancd_filter_reverse.fish
+++ b/functions/_enhancd_filter_reverse.fish
@@ -5,6 +5,6 @@ function _enhancd_filter_reverse
     else
         cat <&0
     end \
-        | _enhancd_command_awk -f "$ENHANCD_ROOT/functions/enhancd/lib/reverse.awk" \
+        | _enhancd_command_awk -f "$ENHANCD_ROOT/lib/reverse.awk" \
         2>/dev/null
 end

--- a/functions/_enhancd_flag_print_help.fish
+++ b/functions/_enhancd_flag_print_help.fish
@@ -1,5 +1,5 @@
 function _enhancd_flag_print_help
     _enhancd_ltsv_open \
-        | _enhancd_command_awk -f "$ENHANCD_ROOT/functions/enhancd/lib/help.awk"
+        | _enhancd_command_awk -f "$ENHANCD_ROOT/lib/help.awk"
     return $status
 end

--- a/functions/_enhancd_help.fish
+++ b/functions/_enhancd_help.fish
@@ -1,5 +1,5 @@
 function _enhancd_help
     _enhancd_ltsv_open \
-        | _enhancd_command_awk -f "$ENHANCD_ROOT/functions/enhancd/lib/help.awk"
+        | _enhancd_command_awk -f "$ENHANCD_ROOT/lib/help.awk"
     return $status
 end

--- a/functions/_enhancd_ltsv_parse.fish
+++ b/functions/_enhancd_ltsv_parse.fish
@@ -11,7 +11,7 @@ function _enhancd_ltsv_parse
             case "-v"
                 set -a args "-v" $argv[(math "$i + 1")]
             case "-f"
-                set -a args "-f" "$ENHANCD_ROOT/functions/enhancd/lib/ltsv.awk"
+                set -a args "-f" "$ENHANCD_ROOT/lib/ltsv.awk"
                 set -a args "-f" $argv[(math "$i + 1")]
                 set query ""
         end
@@ -19,7 +19,7 @@ function _enhancd_ltsv_parse
     end
 
     set -l default_query '{print $0}'
-    set -l ltsv_script (cat "$ENHANCD_ROOT/functions/enhancd/lib/ltsv.awk")
+    set -l ltsv_script (cat "$ENHANCD_ROOT/lib/ltsv.awk")
 
     if not set -q query
         set query $default_query


### PR DESCRIPTION
## WHAT
Update awk scripts paths in fish functions

## WHY
6d07e5af842d14e1b903cbc43e38f60316295426 fixed awk scripts paths in bash/zsh sources, but messed up with ones in fish functions, assuming that `ENHANCD_ROOT` was set to the fish config directory, which is wrong.

In fish sources, `$ENHANCD_ROOT` points to `$fisher_path/functions/enhancd`, with `$fisher_path` being set to `$__fish_config_dir` by default, but can be customized by the user.