### PR TITLE
Use `command` prefix in built-in command

### DIFF
--- a/functions/_enhancd_command_grep.fish
+++ b/functions/_enhancd_command_grep.fish
@@ -1,9 +1,9 @@
 # Overrides grep command
 function _enhancd_command_grep
     if test -n "$argv[1]"; and test -f "$argv[1]"
-        cat "$argv[1]"
+        command cat "$argv[1]"
     else
-        cat <&0
+        command cat <&0
     end \
         | command grep -E $argv 2>/dev/null
 end

--- a/functions/_enhancd_filter_exclude_gitignore.fish
+++ b/functions/_enhancd_filter_exclude_gitignore.fish
@@ -5,7 +5,7 @@ function _enhancd_filter_exclude_gitignore
     else
         # just do read the input and do output
         # if no gitignore file
-        cat <&0
+        command cat <&0
         return 0
     end
 
@@ -13,7 +13,7 @@ function _enhancd_filter_exclude_gitignore
 
     while read ignore
         if test -d $ignore
-            set -a ignores (basename "$ignore")
+            set -a ignores (command basename "$ignore")
         end
     end <"$PWD"/.gitignore
 

--- a/functions/_enhancd_filter_fuzzy.fish
+++ b/functions/_enhancd_filter_fuzzy.fish
@@ -1,6 +1,6 @@
 function _enhancd_filter_fuzzy
     if test -z "$argv[1]"
-        cat <&0
+        command cat <&0
     else
         if test "$ENHANCD_USE_FUZZY_MATCH" = 1
             _enhancd_command_awk \

--- a/functions/_enhancd_filter_join.fish
+++ b/functions/_enhancd_filter_join.fish
@@ -1,7 +1,7 @@
 function _enhancd_filter_join
     if test -n "$argv[1]"; and test -f "$argv[1]"
-        cat "$argv[1]"
+        command cat "$argv[1]"
     else
-        cat <&0
+        command cat <&0
     end | _enhancd_command_awk 'a[$0]++' 2>/dev/null
 end

--- a/functions/_enhancd_filter_reverse.fish
+++ b/functions/_enhancd_filter_reverse.fish
@@ -1,9 +1,9 @@
 # _enhancd_filter_reverse reverses a stdin contents
 function _enhancd_filter_reverse
     if test -n "$argv[1]"; and test -f "$argv[1]"
-        cat "$argv[1]"
+        command cat "$argv[1]"
     else
-        cat <&0
+        command cat <&0
     end \
         | _enhancd_command_awk -f "$ENHANCD_ROOT/lib/reverse.awk" \
         2>/dev/null

--- a/functions/_enhancd_filter_unique.fish
+++ b/functions/_enhancd_filter_unique.fish
@@ -1,8 +1,8 @@
 # _enhancd_filter_unique uniques a stdin contents
 function _enhancd_filter_unique
     if test -n "$argv[1]"; and test -f "$argv[1]"
-        cat "$argv[1]"
+        command cat "$argv[1]"
     else
-        cat <&0
+        command cat <&0
     end | _enhancd_command_awk '!a[$0]++' 2>/dev/null
 end

--- a/functions/_enhancd_history_open.fish
+++ b/functions/_enhancd_history_open.fish
@@ -1,6 +1,6 @@
 function _enhancd_history_open
     if test -f $ENHANCD_DIR/enhancd.log
-        cat "$ENHANCD_DIR/enhancd.log"
+        command cat "$ENHANCD_DIR/enhancd.log"
         return $status
     end
     return 1

--- a/functions/_enhancd_ltsv_open.fish
+++ b/functions/_enhancd_ltsv_open.fish
@@ -3,7 +3,7 @@ function _enhancd_ltsv_open
 
     for config in "$configs"
         if test -f "$config"
-            cat "$config"
+            command cat "$config"
         end
     end
 end

--- a/functions/_enhancd_ltsv_parse.fish
+++ b/functions/_enhancd_ltsv_parse.fish
@@ -19,7 +19,7 @@ function _enhancd_ltsv_parse
     end
 
     set -l default_query '{print $0}'
-    set -l ltsv_script (cat "$ENHANCD_ROOT/lib/ltsv.awk")
+    set -l ltsv_script (command cat "$ENHANCD_ROOT/lib/ltsv.awk")
 
     if not set -q query
         set query $default_query

--- a/functions/enhancd/lib/split.awk
+++ b/functions/enhancd/lib/split.awk
@@ -13,12 +13,12 @@ BEGIN {
     print substr(arg, 1, 1)
 
     if (show_fullpath == 1) {
-        # get dirname from /
-        num = split(s, dirname, "/")
+        # get command dirname from /
+        num = split(s, command dirname, "/")
         for (i = 1; i < num; i++) {
             pre_dir = ""
             for (ii = 1; ii <= i; ii++) {
-                pre_dir = pre_dir "/" dirname[ii]
+                pre_dir = pre_dir "/" command dirname[ii]
             }
             print pre_dir
         }

--- a/init.sh
+++ b/init.sh
@@ -22,7 +22,7 @@ _ENHANCD_FAILURE=60
 
 if [[ -n $BASH_VERSION ]]; then
     # BASH
-    ENHANCD_ROOT="$(builtin cd "$(dirname "$BASH_SOURCE")" && pwd)"
+    ENHANCD_ROOT="$(builtin cd "$(command dirname dirname "$BASH_SOURCE")" && pwd)"
 elif [[ -n $ZSH_VERSION ]]; then
     # ZSH
     ENHANCD_ROOT="${${(%):-%x}:A:h}"

--- a/src/cd.sh
+++ b/src/cd.sh
@@ -11,7 +11,7 @@ __enhancd::cd()
 
     # Read from standard input
     if [[ -p /dev/stdin ]]; then
-        args+=( "$(cat <&0)" )
+        args+=( "$(command cat <&0)" )
     fi
 
     while (( $# > 0 ))

--- a/src/command.sh
+++ b/src/command.sh
@@ -2,10 +2,10 @@
 __enhancd::command::grep()
 {
     if [[ -n $1 ]] && [[ -f $1 ]]; then
-        cat "$1"
+        command cat "$1"
         shift
     else
-        cat <&0
+        command cat <&0
     fi \
         | command grep "$@" 2>/dev/null
 }
@@ -27,7 +27,7 @@ __enhancd::command::awk()
     if type gawk &>/dev/null; then
         gawk ${1:+"${@}"}
     else
-        awk ${1:+"${@}"}
+        command awk ${1:+"${@}"}
     fi
 }
 

--- a/src/completion.zsh
+++ b/src/completion.zsh
@@ -21,12 +21,12 @@ __enhancd::completion::list() {
       echo "$line"
     done
   else
-    dir=$(dirname -- "$1")
+    dir=$(command dirname -- "$1")
     length=$(echo -n "$dir" | wc -c)
     if [ "$dir" = "/" ]; then
       length=0
     fi
-    seg=$(basename -- "$1")
+    seg=$(command basename -- "$1")
     starts_with_dir=$( \
       command find -L "$dir" -mindepth 1 -maxdepth 1 -type d \
           2>/dev/null | cut -b $(( ${length} + 2 ))- | \sed '/^$/d' \
@@ -101,7 +101,7 @@ __enhancd::completion::complete() {
     base="${(Q)@[-1]}"
     if [[ "$base" != */ ]]; then
       if [[ "$base" == */* ]]; then
-        base="$(dirname -- "$base")"
+        base="$(command dirname -- "$base")"
         if [[ ${base[-1]} != / ]]; then
           base="$base/"
         fi

--- a/src/filepath.sh
+++ b/src/filepath.sh
@@ -59,7 +59,7 @@ __enhancd::filepath::abs()
     cwd="${PWD%/*}"
     dir="${1}"
     if [[ -p /dev/stdin ]]; then
-        dir="$(cat <&0)"
+        dir="$(command cat <&0)"
     fi
     if [[ -z ${dir} ]]; then
         return 1

--- a/src/filter.sh
+++ b/src/filter.sh
@@ -13,9 +13,9 @@ __enhancd::filter::exists()
 __enhancd::filter::join()
 {
     if [[ -n $1 ]] && [[ -f $1 ]]; then
-        cat "$1"
+        command cat "$1"
     else
-        cat <&0
+        command cat <&0
     fi | __enhancd::command::awk 'a[$0]++' 2>/dev/null
 }
 
@@ -23,9 +23,9 @@ __enhancd::filter::join()
 __enhancd::filter::unique()
 {
     if [[ -n $1 ]] && [[ -f $1 ]]; then
-        cat "$1"
+        command cat "$1"
     else
-        cat <&0
+        command cat <&0
     fi | __enhancd::command::awk '!a[$0]++' 2>/dev/null
 }
 
@@ -33,9 +33,9 @@ __enhancd::filter::unique()
 __enhancd::filter::reverse()
 {
     if [[ -n $1 ]] && [[ -f $1 ]]; then
-        cat "$1"
+        command cat "$1"
     else
-        cat <&0
+        command cat <&0
     fi \
         | __enhancd::command::awk -f "$ENHANCD_ROOT/functions/enhancd/lib/reverse.awk" \
         2>/dev/null
@@ -62,7 +62,7 @@ __enhancd::filter::interactive()
     local stdin="${1}"
 
     if [[ -z ${stdin} ]] || [[ -p /dev/stdin ]]; then
-        stdin="$(cat <&0)"
+        stdin="$(command cat <&0)"
     fi
 
     if [[ -z ${stdin} ]]; then
@@ -136,7 +136,7 @@ __enhancd::filter::exclude_gitignore()
     else
         # just do read the input and do output
         # if no gitignore file
-        cat <&0
+        command cat <&0
         return 0
     fi
 
@@ -144,7 +144,7 @@ __enhancd::filter::exclude_gitignore()
     while read ignore
     do
         if [[ -d ${ignore} ]]; then
-            ignores+=( "$(basename ${ignore})" )
+            ignores+=( "$(command basename ${ignore})" )
         fi
     done <${PWD}/.gitignore
 

--- a/src/history.sh
+++ b/src/history.sh
@@ -1,7 +1,7 @@
 __enhancd::history::open()
 {
     if [[ -f $ENHANCD_DIR/enhancd.log ]]; then
-        cat "$ENHANCD_DIR/enhancd.log"
+        command cat "$ENHANCD_DIR/enhancd.log"
         return $?
     fi
     return 1

--- a/src/ltsv.sh
+++ b/src/ltsv.sh
@@ -10,7 +10,7 @@ __enhancd::ltsv::open()
     for config in "${configs[@]}"
     do
         if [[ -f ${config} ]]; then
-            cat "${config}"
+            command cat "${config}"
         fi
     done
 }
@@ -41,7 +41,7 @@ __enhancd::ltsv::parse()
     done
 
     local default_query='{print $0}'
-    local ltsv_script="$(cat "$ENHANCD_ROOT/functions/enhancd/lib/ltsv.awk")"
+    local ltsv_script="$(command cat "$ENHANCD_ROOT/functions/enhancd/lib/ltsv.awk")"
     local awk_scripts="${ltsv_script} ${query:-$default_query}"
 
     __enhancd::command::awk ${args[@]} "${awk_scripts}"


### PR DESCRIPTION
## WHAT
Update https://github.com/b4b4r07/enhancd/pull/136.

## WHY
(Write the motivation why you submit this pull request)
As written in https://github.com/b4b4r07/enhancd/pull/136, the display is broken if built-in commands have an alias on it.

In addition to `cat`, we have also added prefixes for `awd`, `sed`, `basename`, and `dirname`.
(based on https://github.com/b4b4r07/enhancd/pull/136#issuecomment-737693844)