### PR TITLE
fish: do not rely on fisher variable to find the plugin root

### DIFF
--- a/conf.d/enhancd.fish
+++ b/conf.d/enhancd.fish
@@ -3,7 +3,8 @@ function __enhancd_install --on-event enhancd_install
     set -Ux ENHANCD_FILTER
     set -Ux ENHANCD_COMMAND "cd"
 
-    set -Ux ENHANCD_ROOT "$fisher_path/functions/enhancd"
+    set --local root (status filename | string replace --regex '/[^/]+$' '' | string replace --regex '/[^/]+$' '')
+    set -Ux ENHANCD_ROOT "$root/functions/enhancd"
 
     set -Ux ENHANCD_DIR "$HOME/.enhancd"
     set -Ux ENHANCD_DISABLE_DOT 0


### PR DESCRIPTION
## WHAT
fisher does not expose the `fisher_path` variable to plugins, so the plugin root directory must be derived from the executed file path.

## WHY
When trying to use enhancd I get this error:
```
> cd somewhere
awk: can't open file /functions/enhancd/lib/fuzzy.awk
```

See https://github.com/jorgebucaran/fisher/issues/643
and example fix in tide: https://github.com/IlanCosman/tide/pull/65/files#diff-03d14d12bce8e3fa8a268acb8958f88c88c631f13f6f33312b6cc249ab7742a6R9