### PR TITLE
Fix trailing newline in variable passed to awk when changing to relative path

### DIFF
--- a/functions/_enhancd_filepath_abs.fish
+++ b/functions/_enhancd_filepath_abs.fish
@@ -13,8 +13,6 @@ function _enhancd_filepath_abs
         return 1
     end
 
-    echo "cwd : -$cwd- -- dir : -$dir-" >$HOME/debug.txt
-
     _enhancd_command_awk \
         -f "$ENHANCD_ROOT/lib/to_abspath.awk" \
         -v cwd="$cwd" \

--- a/functions/_enhancd_filepath_abs.fish
+++ b/functions/_enhancd_filepath_abs.fish
@@ -6,7 +6,7 @@ function _enhancd_filepath_abs
     if test -z "$dir"; or test -p /dev/stdin
         read -z dir
         # trim newline for awk scripts to works correctly
-        string trim -c '\n' "$dir"
+        set dir (string trim -c '\n' "$dir")
     end
 
     if test -z "$dir"


### PR DESCRIPTION
## WHAT
When trimming newlines from the `dir` variable using `string trim` the original variable is mistakenly left unmodified.

## WHY
When running `cd ..` I'm getting:
```
awk: newline in string /Users/.../... at source line 1
```
