### PR TITLE
Fish fixes

### DIFF
--- a/functions/_enhancd_cd_after.fish
+++ b/functions/_enhancd_cd_after.fish
@@ -1,10 +1,11 @@
 function _enhancd_cd_after
-    set -l list
-    set list (_enhancd_history_update)
+    # Don't split on newlines throughout this function:
+    set -l IFS ""
+
+    set -l list (_enhancd_history_update)
 
     if test -n "$list"
-        # Workaround to print one folder per line
-        string replace -a ' ' '\n' $list >"$ENHANCD_DIR/enhancd.log"
+        echo "$list" >"$ENHANCD_DIR/enhancd.log"
     end
 
     if test -n "$ENHANCD_HOOK_AFTER_CD"

--- a/functions/_enhancd_filepath_abs.fish
+++ b/functions/_enhancd_filepath_abs.fish
@@ -6,7 +6,7 @@ function _enhancd_filepath_abs
     if test -z "$dir"; or test -p /dev/stdin
         read -z dir
         # trim newline for awk scripts to works correctly
-        set dir (string trim -c '\n' "$dir")
+        set dir (string trim -c \n "$dir")
     end
 
     if test -z "$dir"

--- a/functions/_enhancd_source_default.fish
+++ b/functions/_enhancd_source_default.fish
@@ -3,5 +3,9 @@ function _enhancd_source_default
         echo "$HOME"
         return 0
     end
-    string split '\n' (_enhancd_entry_git_root) (_enhancd_history_list) | _enhancd_filter_interactive
+
+    begin
+        _enhancd_entry_git_root
+        _enhancd_history_list
+    end | _enhancd_filter_interactive
 end


### PR DESCRIPTION
## WHAT
Fix some issues in fish:

* Literal `\n`s in history entries.
* Parent traversal via `..` doesn't work because `filepath_abs` doesn't properly trim the newline character. After the newline that is still there gets translated by fish to a space (via IFS), it results in the `dir` variable having an extra trailing space. The resulting string isn't a real path, so the awk script fails on it.

## WHY
Directories with spaces end up showing with literal `\n`s, like:

```
/Users/.../VirtualBox\nVMs
```

And `..` doesn't work.