### PR TITLE
Use function instead of alias in Fish

### DIFF
--- a/conf.d/enhancd.fish
+++ b/conf.d/enhancd.fish
@@ -37,6 +37,8 @@ function __enhancd_install --on-event enhancd_install
     if not test -f "$ENHANCD_DIR/enhancd.log"
         touch "$ENHANCD_DIR/enhancd.log"
     end
+
+    alias $ENHANCD_COMMAND 'enhancd'
 end
 
 function __enhancd_uninstall --on-event enhancd_uninstall
@@ -63,7 +65,9 @@ function __enhancd_uninstall --on-event enhancd_uninstall
 end
 
 # alias to enhancd
-eval "alias $ENHANCD_COMMAND 'enhancd'"
+if test -n "$ENHANCD_COMMAND"
+    alias $ENHANCD_COMMAND 'enhancd'
+end
 
 # bindings
 bind \ef '_enhancd_complete'

--- a/conf.d/enhancd.fish
+++ b/conf.d/enhancd.fish
@@ -38,7 +38,7 @@ function __enhancd_install --on-event enhancd_install
         touch "$ENHANCD_DIR/enhancd.log"
     end
 
-    alias $ENHANCD_COMMAND 'enhancd'
+    _enhancd_alias
 end
 
 function __enhancd_uninstall --on-event enhancd_uninstall
@@ -66,7 +66,7 @@ end
 
 # alias to enhancd
 if test -n "$ENHANCD_COMMAND"
-    alias $ENHANCD_COMMAND 'enhancd'
+    _enhancd_alias
 end
 
 # bindings

--- a/functions/_enhancd_alias.fish
+++ b/functions/_enhancd_alias.fish
@@ -1,0 +1,5 @@
+function _enhancd_alias
+    function $ENHANCD_COMMAND
+        enhancd $argv
+    end
+end


### PR DESCRIPTION
## WHAT

Use function instead of alias in Fish, for better speed.
Also fix error when user installs the plugin.

## WHY
```
kid ~> fisher install b4b4r07/enhancd
fisher install version 4.1.0
Fetching https://codeload.github.com/b4b4r07/enhancd/tar.gz/HEAD
Installing b4b4r07/enhancd
(omitted)
alias: Body cannot be empty
Installed 1 plugin/s
```