### PR TITLE
zsh: Fix handling of directory names containing spaces

### DIFF
--- a/src/sources.sh
+++ b/src/sources.sh
@@ -51,11 +51,11 @@ __enhancd::sources::default()
         echo "$HOME"
         return 0
     fi
-    local list=($(__enhancd::entry::git::root) $(__enhancd::history::list))
 
-    for item in ${list[*]}; do
-        echo $item
-    done | __enhancd::filter::interactive
+    {
+        __enhancd::entry::git::root
+        __enhancd::history::list
+    } | __enhancd::filter::interactive
 }
 
 __enhancd::sources::argument()


### PR DESCRIPTION
## WHAT
In accordance with the same fix for fish in https://github.com/b4b4r07/enhancd/pull/145/commits/474328990d9ab6ee1f142795be192cc7df12966d

## WHY
Directories that contain spaces in the name end up being split into 2 separate entries.
