### PR TITLE
Make README toc link work

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 <br>
 <b><a href="#installation">Installation</a></b>
 |
-<b><a href="#configuration">Configuration</a></b>
+<b><a href="#configurations">Configurations</a></b>
 |
 <b><a href="#references">References</a></b>
 |


### PR DESCRIPTION
## WHAT
- Fix anchor link for `#configuration*s*` in README.

## WHY
- Currently it does not work.