### PR TITLE
Optimize

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -20,10 +20,10 @@ export _ENHANCD_VERSION="2.2.4"
 _ENHANCD_SUCCESS=0
 _ENHANCD_FAILURE=60
 
-if [[ -n $BASH_VERSION ]]; then
+if ps -p $$ | grep -i --quiet 'bash$'; then
     # BASH
     ENHANCD_ROOT="$( dirname "${BASH_SOURCE[0]}" )"
-elif [[ -n $ZSH_VERSION ]]; then
+elif ps -p $$ | grep -i --quiet 'zsh$'; then
     # ZSH
     ENHANCD_ROOT="${${(%):-%x}:A:h}"
     compdef _cd __enhancd::cd

--- a/init.sh
+++ b/init.sh
@@ -20,10 +20,10 @@ export _ENHANCD_VERSION="2.2.4"
 _ENHANCD_SUCCESS=0
 _ENHANCD_FAILURE=60
 
-if ps -p $$ | grep -i --quiet 'bash$'; then
+if ps -p $$ | grep --quiet 'bash$'; then
     # BASH
     ENHANCD_ROOT="$( dirname "${BASH_SOURCE[0]}" )"
-elif ps -p $$ | grep -i --quiet 'zsh$'; then
+elif ps -p $$ | grep --quiet 'zsh$'; then
     # ZSH
     ENHANCD_ROOT="${${(%):-%x}:A:h}"
     compdef _cd __enhancd::cd

--- a/init.sh
+++ b/init.sh
@@ -22,7 +22,7 @@ _ENHANCD_FAILURE=60
 
 if [[ -n $BASH_VERSION ]]; then
     # BASH
-    ENHANCD_ROOT="$(builtin cd "$(command dirname "$BASH_SOURCE")" && pwd)"
+    ENHANCD_ROOT="$( dirname "${BASH_SOURCE[0]}" )"
 elif [[ -n $ZSH_VERSION ]]; then
     # ZSH
     ENHANCD_ROOT="${${(%):-%x}:A:h}"


### PR DESCRIPTION
## WHAT
Changes:
- Validation of what the current shell is
- The way `ENHANCD_ROOT`'s value is being computed in case when Bash is the current shell.

## WHY
- Use a more robust way of validating the current shell; use `ps -p $$` to check the current shell.
- Optimize/simplify computation of value of `ENHANCD_ROOT` in case when the current shell is Bash.
	- Using `"$(builtin cd "$(command dirname "$BASH_SOURCE")" && pwd)"` to compute the path of the sourced file seems is more than necessary.
	- Just using `"$( dirname "${BASH_SOURCE[0]}" )"` should do the job.

Got the idea(s) while developing myself a cd alternative (inspired by `enhancd`) - [SmartCd](https://github.com/CodesOfRishi/smartcd).