### PR TITLE
fish version pipe to cd fix

### DIFF
--- a/functions/cd_pipe.fish
+++ b/functions/cd_pipe.fish
@@ -1,0 +1,24 @@
+
+alias cd "cdin start"
+
+function cdin
+    if count $argv > /dev/null
+        if [ "$argv[1]" = 'start' ]
+            alias cd "cd"
+            if [ "$argv[2]" != '' ]
+                cd $argv[2]
+            else
+                fzf_cd
+            end
+            alias cd "cdin start"
+        end
+    end
+end
+
+
+function fzf_cd
+    read -la line; set var (command find $PWD -name $line)
+    set dname (dirname $var)
+    cd (find $PWD -name (ls $dname|fzf))
+#     # find $dname -type d | fzf
+end


### PR DESCRIPTION
#169 

fish version pipe to cd fix

[](https://github.com/b4b4r07/enhancd#issues)Issues

    Fish version
        Because of how fish piping works, it's not possible to pipe to cd like : ls / | cd