### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,12 @@ then,
 afx install
 ```
 
+### Fig
+
+Install `enhancd` with [Fig](https://fig.io) on zsh, bash, or fish with just one click.
+
+<a href="https://fig.io/plugins/other/enhancd" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 ### Bash
 
 ```console


### PR DESCRIPTION
## WHAT
Added Fig as an installation option in the README.

## WHY
We recently listed `enhancd` on [Fig Plugin Store](https://fig.io/plugins), so we'd love to have Fig listed as a download method on your readme. 

Thanks so much and please let me know if you have any questions!


