### PR TITLE
fish: Do not change directory if Ctrl-C pressed in fuzzy search

### DIFF
--- a/functions/_enhancd_cd_builtin.fish
+++ b/functions/_enhancd_cd_builtin.fish
@@ -1,5 +1,11 @@
 function _enhancd_cd_builtin
     set -l code 0
+    
+    # in case nothing was passed in argv, default to working directory
+    if test -z "$argv"
+        set argv (pwd)
+    end
+    
     _enhancd_cd_before
     builtin cd $argv
     set code $status


### PR DESCRIPTION
## WHY
In fish, running `cd foobar` will cd to the home directory (effectively running `cd` with no arguments) if the target directory does not exist. The same behavior happens if `Ctrl-C` or `Esc` is pressed while the fuzzy search is open.

Related: #161 

## WHAT
This fix will make enhancd default to the working directory if no arguments are passed in, since args is only empty when there is an error. 

Fix suggested by @Gorthog in #161