### PR TITLE
Add 'format' label to format custom input before passing cd

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,11 +202,14 @@ short:-G	long:--ghq	desc:Show ghq path	func:ghq list --full-path	condition:which
 
 Label | Description
 ---|---
-short | a short option (e.g. `-G`)
-long | a long option (e.g. `--ghq`)
+short (`*`) | a short option (e.g. `-G`)
+long (`*`) | a long option (e.g. `--ghq`)
 desc | a description for the option
-func | a command which returns directory list (e.g. `ghq list --full-path`)
+func (`*`) | a command which returns directory list (e.g. `ghq list --full-path`)
 condition | a command which determine that the option should be implemented or not (e.g. `which ghq`)
+format | a string which indicates how to format a line selected by the filter before passing cd command. `%` is replaced as a selected line and then passed to cd command (e.g. `$HOME/src/%`). This is useful for the case that input sources for the interactive filter are not a full-path.
+
+> **Note**: `*`: A required key. But either `short` or `long` is good enough.
 
 <!-- <img width="600" alt="" src="https://user-images.githubusercontent.com/4442708/229298741-236f2920-cde2-4184-9fd3-72849af7a223.png"> -->
 

--- a/functions/enhancd.fish
+++ b/functions/enhancd.fish
@@ -59,19 +59,34 @@ function enhancd
                     set -a opts "$argv[1]"
                 else
                     set -l opt "$argv[1]"
-                    set -l arg "$argv[2]"
-                    set -l func
-                    set func (_enhancd_ltsv_get "$opt" "func")
+                    set -l func cond format
                     set cond (_enhancd_ltsv_get "$opt" "condition")
+                    set func (_enhancd_ltsv_get "$opt" "func")
+                    set format (_enhancd_ltsv_get "$opt" "format")
                     if not _enhancd_command_run "$cond"
                         echo "$opt: defined but require '$cond'" >&2
                         return 1
                     end
                     if test -z $func
-                        echo "$opt: no such option" >&2
+                        echo "$opt: 'func' label is required" >&2
                         return 1
                     end
+                    if not string match --quiet '*%*' $format
+                        echo "$opt: 'format' label needs to include '%' (selected line)" >&2
+                        return 1
+                    fi
                     _enhancd_command_run "$func" "$arg" | _enhancd_filter_interactive
+                    set -l seleted
+                    if test -z $format
+                        set selected (_enhancd_command_run "$func" | _enhancd_filter_interactive)
+                    else
+                        # format is maybe including $HOME etc. need magic line of 'eval printf' to expand that.
+                        set selected (_enhancd_command_run "$func" | _enhancd_filter_interactive | xargs -I% echo (eval printf "%s" "$format"))
+                    end
+                    set code $status
+                    set -a args $selected
+                    break
+
                 end
 
             case '*'

--- a/functions/enhancd.fish
+++ b/functions/enhancd.fish
@@ -71,7 +71,7 @@ function enhancd
                         echo "$opt: 'func' label is required" >&2
                         return 1
                     end
-                    if not string match --quiet '*%*' $format
+                    if test -n $format; and not string match --quiet '*%*' $format
                         echo "$opt: 'format' label needs to include '%' (selected line)" >&2
                         return 1
                     fi

--- a/functions/enhancd/lib/help.awk
+++ b/functions/enhancd/lib/help.awk
@@ -10,6 +10,8 @@ BEGIN {
 
 # Skip commented line starting with # or //
 /^(#|\/\/)/ { next }
+# Skip empty line
+/^ *$/ { next }
 
 {
     condition = ltsv("condition")

--- a/src/cd.sh
+++ b/src/cd.sh
@@ -89,7 +89,7 @@ __enhancd::cd()
             echo "${opt}: 'func' label is required" >&2
             return 1
           fi
-          if [[ ${format//\%/} == ${format} ]]; then
+          if [[ -n ${format} ]] && [[ ${format//\%/} == "${format}" ]]; then
             echo "${opt}: 'format' label needs to include '%' (selected line)" >&2
             return 1
           fi


### PR DESCRIPTION
## WHAT

Add new label `format` to config.ltsv. 

## WHY

To format custom input

```tsv
short:-G	long:--ghq	desc:Show ghq path	func:ghq list	condition:which ghq	format:$HOME/src/%
```

These lines are not full path (on gif video) but it's done with no error. Because enhancd formats the selected path base on `format` before passing cd command.

![outout](https://user-images.githubusercontent.com/4442708/229203170-0c12f791-1bef-4787-8a04-d411af2b82db.gif)

