### PR TITLE
fix fish errors

### DIFF
--- a/functions/_enhancd_filepath_walk.fish
+++ b/functions/_enhancd_filepath_walk.fish
@@ -1,5 +1,5 @@
 function _enhancd_filepath_walk
-    set -a dirs ($PWD _enhancd_filepath_get_parent_dirs)
+    set -a dirs $PWD (_enhancd_filepath_get_parent_dirs)
 
     for dir in $dirs
         command find "$dir" -maxdepth 1 -type d -name '\.*' -prune -o -type d -print

--- a/functions/_enhancd_filter_interactive.fish
+++ b/functions/_enhancd_filter_interactive.fish
@@ -13,7 +13,7 @@ function _enhancd_filter_interactive
     set -l filter (_enhancd_helper_parse_filter_string "$ENHANCD_FILTER")
     set -l count (echo "$stdin" | _enhancd_command_grep -c "")
 
-    if test $ENHANCD_USE_ABBREV = true
+    if test "$ENHANCD_USE_ABBREV" = true
         function _enhancd_filter_interactive_abbrev
             while read -l line
                 string replace --regex "^$HOME" "~" "$line"

--- a/functions/enhancd.fish
+++ b/functions/enhancd.fish
@@ -74,9 +74,9 @@ function enhancd
                     if test -n $format; and not string match --quiet '*%*' $format
                         echo "$opt: 'format' label needs to include '%' (selected line)" >&2
                         return 1
-                    fi
+                    end
                     _enhancd_command_run "$func" "$arg" | _enhancd_filter_interactive
-                    set -l seleted
+                    set -l selected
                     if test -z $format
                         set selected (_enhancd_command_run "$func" | _enhancd_filter_interactive)
                     else

--- a/src/filepath.sh
+++ b/src/filepath.sh
@@ -13,9 +13,9 @@ __enhancd::filepath::walk()
 {
   local -a dirs
 
-  # __enhancd::filepath::get_parent_dirs does not return $PWD itself
-  # so add it to array expressly
-  dirs=( "${PWD}" $(__enhancd::filepath::get_parent_dirs "${1:-${PWD}}") )
+  # __enhancd::filepath::get_parent_dirs does not return $PWD itself,
+  # so add it to the array explicitly
+  dirs=( "${PWD}" "$(__enhancd::filepath::get_parent_dirs "${1:-${PWD}}")" )
 
   for dir in "${dirs[@]}"
   do


### PR DESCRIPTION
## WHAT
fixed some bugs I and [several others](https://github.com/b4b4r07/enhancd/issues/200) encountered after the latest update
- Apple M1 macOS Ventura 13.2.1, iTerm2 3.4.19, fish 3.6.1, fisher 4.4.3, tide 5.5.1
## WHY
I was unable to `cd` without seeing errors 😵‍💫

```
~/.config/fish/functions/enhancd.fish (line 58): Missing end to balance this if statement
                if _enhancd_helper_is_default_flag "$argv[1]"
                ^^
from sourcing file ~/.config/fish/functions/enhancd.fish
	called on line 1 of file ~/.config/fish/conf.d/enhancd.fish
in function 'cd' with arguments '../'
source: Error while reading file '/Users/peeviddy/.config/fish/functions/enhancd.fish'
fish: Unknown command: enhancd
~/.config/fish/conf.d/enhancd.fish (line 3):
        enhancd $argv
        ^~~~~~^
in function 'cd' with arguments '../'
```

thanks to @martonperei for some of the lines I added in this PR