### PR TITLE
Do not quote multiple lines to deal as single line

### DIFF
--- a/src/filepath.sh
+++ b/src/filepath.sh
@@ -15,7 +15,7 @@ __enhancd::filepath::walk()
 
   # __enhancd::filepath::get_parent_dirs does not return $PWD itself,
   # so add it to the array explicitly
-  dirs=( "${PWD}" "$(__enhancd::filepath::get_parent_dirs "${1:-${PWD}}")" )
+  dirs=( "${PWD}" $(__enhancd::filepath::get_parent_dirs "${1:-${PWD}}") )
 
   for dir in "${dirs[@]}"
   do


### PR DESCRIPTION
## WHAT

this current behavior


```
+__enhancd::filepath::walk:6> dirs=( /etc/apache2 $'/etc\n/' ) 
```
shoule be

```
+__enhancd::filepath::walk:6> dirs=( /etc/apache2 /etc ) 
````

## WHY

https://github.com/b4b4r07/enhancd/issues/209 (Especially https://github.com/b4b4r07/enhancd/issues/209#issuecomment-1526928287)
