### PR TITLE
Change $0 handler

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -24,7 +24,9 @@ if [[ -n ${BASH_VERSION} ]]; then
   ENHANCD_ROOT="$(builtin cd "$(command dirname "${BASH_SOURCE}")" && pwd)"
 elif [[ -n ${ZSH_VERSION} ]]; then
   # ZSH
-  ENHANCD_ROOT="${${(%):-%x}:A:h}"
+  0="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
+  0="${${(M)0:#/*}:-$PWD/$0}"
+  ENHANCD_ROOT="${0:A:h}"
   compdef _cd __enhancd::cd
 fi
 


### PR DESCRIPTION
## WHAT

I changed $0 handling for zsh

## WHY
In my [plugin manager](https://github.com/zpm-zsh/zpm), I use a trick: I copy the main plugin file into a `/tmp` dir in a big one file. This increase file reading for ~10 milliseconds(yes, milliseconds!). But in this case, zsh plugins can lose plugin’s location. But we can prevent this using this $0 handling

https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html#zero-handling
